### PR TITLE
add basic blink firmware for ESP32 DevKitC

### DIFF
--- a/Hardware/caxora_hw.ino
+++ b/Hardware/caxora_hw.ino
@@ -1,0 +1,28 @@
+/*
+ * Hardware: ESP32 DevKitC (ESP32-WROOM-32)
+ * Description: Blinks the built-in LED on GPIO 2.
+ * Author: Your Name
+ * Date: [Current Date]
+ */
+
+// Pin definition for the built-in LED on ESP32 DevKitC
+const int builtInLed = 2; // GPIO 2
+
+void setup() {
+  // Initialize the built-in LED pin as an output.
+  pinMode(builtInLed, OUTPUT);
+  
+  // (Optional) Start serial communication for debugging
+  Serial.begin(115200); // ESP32 commonly uses 115200 baud rate
+  Serial.println("Setup complete. Starting blink loop...");
+}
+
+void loop() {
+  Serial.println("LED ON");
+  digitalWrite(builtInLed, HIGH); // Turn the LED on
+  delay(1000);                    // Wait for 1000 milliseconds (1 second)
+  
+  Serial.println("LED OFF");
+  digitalWrite(builtInLed, LOW);  // Turn the LED off
+  delay(1000);                    // Wait for 1 second
+}


### PR DESCRIPTION
- Initialize platform project for ESP32 Arduino framework
- Implement core blink logic on GPIO2 (built-in LED)
- Configure serial monitor output for runtime debugging
- Set baud rate to 115200 for stable ESP32 communication